### PR TITLE
Remove the check for categorical values order

### DIFF
--- a/src/main/java/org/jpmml/converter/PMMLEncoder.java
+++ b/src/main/java/org/jpmml/converter/PMMLEncoder.java
@@ -20,6 +20,7 @@ package org.jpmml.converter;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -182,7 +183,7 @@ public class PMMLEncoder {
 			List<String> existingValues = PMMLUtil.getValues(dataField);
 			if(existingValues != null && existingValues.size() > 0){
 
-				if((existingValues).equals(values)){
+				if (new HashSet(existingValues).equals(new HashSet(values))){
 					break dataField;
 				}
 


### PR DESCRIPTION
According to [the PMML docs](http://dmg.org/pmml/v4-1/DataDictionary.html) ,

>  Categorical field values can only be tested for equality, while ordinal field values in addition have an order defined.
> 
> If the application algorithm for some class of models does not require any special treatment of ordinal fields, then they can be interpreted as categorical fields.

"categorical" doesn't require an order defined. Users should use "ordinal" field instead of "categorical" if they want the order.
So, no need to check categorical field's order.

For example, in jpmml-spark [here](https://github.com/jpmml/jpmml-sparkml/blob/1.3.4/src/main/java/org/jpmml/sparkml/ModelConverter.java#L98-L100) , the values' order is hardcoded. The hardcoded order `[0, 1]` may be different from the order given by spark ML `[1, 0]`. For categorical field, they should be the same thing.
