### PR TITLE
fix pom guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>[21.0,)</version>
+			<version>21.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>


### PR DESCRIPTION
While trying to build a project with JPMML SkLearn I'm failing to build the dependencies with bazel-deps due to wrong version in the pom file, I would really appreciate if you can fix this by merging the PR and publish the package to maven for all it's versions that are affected